### PR TITLE
Add a JavaScript quick-start script

### DIFF
--- a/example-code/.gitignore
+++ b/example-code/.gitignore
@@ -1,0 +1,10 @@
+# Ignore JavaScript dependency/module files.
+/node_modules/
+/package-lock.json
+/package.json
+
+# Ignore Python dependency/package files.
+/.venv/
+/poetry.lock
+/pyproject.toml
+/requirements.txt

--- a/example-code/README.md
+++ b/example-code/README.md
@@ -22,7 +22,7 @@ You can then either set a `FORGE_API_KEY` environment variable with your API key
 
 * Install Python 3.
 * Install the python [requests library](https://pypi.org/project/requests/).
-* Inside of this directory (`example-code`), invoke the python script in the command line via `FORGEAPI_KEY=<your-api-key python3 quickstart.py`.
+* Inside of this directory (`example-code`), invoke the python script in the command line via `FORGE_API_KEY=<your-api-key python3 quickstart.py`.
 
 ### Expected Outcome
 

--- a/example-code/README.md
+++ b/example-code/README.md
@@ -2,27 +2,41 @@
 
 This directory contains examples of code interacting with Forge.
 
-## A Quick Start Script
+## Quick-Start Scripts
 
-The python file `quickstart.py` will create a Circom circuit object in Forge. Then, it will upload a gzipped sample circuit file (cf. `../circom/multiplier2.tar.gz` in this repo) and compile. Once a proof has finished executing, the code will then verify that proof.
+We provide quick-start scripts in both JavaScript ([`quickstart.js`](./quickstart.js)) and Python ([`quickstart.py`](./quickstart.py)).
+These scripts will create a Circom circuit object in Forge, upload a gzipped sample circuit file (located at [`../circom/multiplier2.tar.gz`](../circom/multiplier2.tar.gz)), and compile it.
+Once a proof has finished executing, the code will then verify that proof.
 
-### To Run
-* Install python 3
-* Install the python [requests library](https://pypi.org/project/requests/)
-* Replace the string in line 8 of `quickstart.py` with your own API key. (The Forge GitBook explains how to obtain your API key [here](https://sindri-labs.gitbook.io/forge/ZpTt7gQVuHU2jgnnKBQl/forge/using-forge/access-management#api-authentication))
-* Inside of this directory (`example-code`), invoke the python script in the command line via `python3 quickstart.py`
+You will need a Forge API key in order to run the scripts.
+The Forge GitBook explains how to obtain your API key [here](https://sindri-labs.gitbook.io/forge/ZpTt7gQVuHU2jgnnKBQl/forge/using-forge/access-management#api-authentication).
+You can then either set a `FORGE_API_KEY` environment variable with your API key, or modify the value of the `API_KEY` global variable in the scripts before running them.
+
+### JavaScript ([`quickstart.js`](./quickstart.js))
+
+* Make sure you have Node.js installed.
+* Install the necessary dependencies by running `npm install axios form-data`.
+* Inside this directory (`example-code`), run the script using `FORGE_API_KEY=<your-api-key> node quickstart.js`.
+
+### Python ([`quickstart.py`](./quickstart.py))
+
+* Install Python 3.
+* Install the python [requests library](https://pypi.org/project/requests/).
+* Inside of this directory (`example-code`), invoke the python script in the command line via `FORGEAPI_KEY=<your-api-key python3 quickstart.py`.
 
 ### Expected Outcome
 
-You should see the following printed to stdout:
+For both scripts, you should see the following printed to `stdout`:
+
 ```
 1. Creating circuit...
 Circuit poll exited after 9 seconds with status: Ready
 Circuit compilation succeeded!
 2. Proving circuit...
 Proof poll exited after 0 seconds with status: Ready
-Circuit proof output signal: 294
 3. Verifing proof...
 Proof was valid
+Circuit proof output signal: 294
 ```
-Note that the circuit computes the product of two inputs `a=7` and `b=42`, so the output signal should change accordingly when you alter line 75 of `quickstart.py`
+
+Note that the circuit computes the product of two inputs `a=7` and `b=42`, so the output signal should change accordingly when you alter `proof_input`/`proofInput` in the input scripts.

--- a/example-code/quickstart.js
+++ b/example-code/quickstart.js
@@ -1,0 +1,126 @@
+const fs = require("fs");
+const path = require("path");
+const process = require("process");
+
+// NOTE: Install dependencies with `npm i axios form-data`.
+const axios = require("axios");
+const FormData = require("form-data");
+
+// NOTE: Provide your API key here.
+const API_KEY = process.env.FORGE_API_KEY || "";
+
+const API_VERSION = "v1";
+const API_URL = `https://forge.sindri.app/api/${API_VERSION}`;
+
+const apiKeyQueryString = `?api_key=${API_KEY}`;
+const headersUrlEncode = {
+  Accept: "application/json",
+  "Content-Type": "application/x-www-form-urlencoded",
+};
+
+// Utility to poll a detail API endpoint until the status is `Ready` or `Failed`.
+// Returns the response object of the final request or throws an error if the timeout is reached.
+async function pollForStatus(endpoint, timeout = 20 * 60) {
+  for (let i = 0; i < timeout; i++) {
+    const response = await axios.get(API_URL + endpoint + apiKeyQueryString, {
+      headers: headersUrlEncode,
+      validateStatus: (status) => status === 200,
+    });
+
+    const status = response.data.status;
+    if (["Ready", "Failed"].includes(status)) {
+      console.log(`Poll exited after ${i} seconds with status: ${status}`);
+      return response;
+    }
+
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+
+  throw new Error(`Polling timed out after ${timeout} seconds.`);
+}
+
+async function main() {
+  try {
+    // Create a new circuit.
+    console.log("1. Creating circuit...");
+    const createResponse = await axios.post(
+      API_URL + "/circuit/create" + apiKeyQueryString,
+      {
+        circuit_name: "multiplier_example",
+        circuit_type: "Circom C Groth16 bn254",
+      },
+      { headers: headersUrlEncode, validateStatus: (status) => status === 201 },
+    );
+    const circuitId = createResponse.data.circuit_id;
+
+    // Load the circuit's `tar.gz` file.
+    const circuitFilePath = path.join(
+      __dirname,
+      "..",
+      "circom",
+      "multiplier2.tar.gz",
+    );
+    const circuitFileBuffer = fs.readFileSync(circuitFilePath);
+
+    // Upload the circuit file.
+    const uploadFormData = new FormData();
+    uploadFormData.append("files", circuitFileBuffer, {
+      filename: "multiplier2.tar.gz",
+    });
+    await axios.post(
+      API_URL + `/circuit/${circuitId}/uploadfiles` + apiKeyQueryString,
+      uploadFormData,
+      { validateStatus: (status) => status === 201 },
+    );
+
+    // Initiate circuit compilation.
+    await axios.post(
+      API_URL + `/circuit/${circuitId}/compile` + apiKeyQueryString,
+      { validateStatus: (status) => status === 201 },
+    );
+
+    // Poll the circuit detail endpoint until the compilation status is `Ready` or `Failed`.
+    const {
+      data: { status: compileStatus },
+    } = await pollForStatus(`/circuit/${circuitId}/detail`);
+
+    // Check for compilation issues.
+    if (compileStatus === "Failed") {
+      throw new Error("Circuit compilation failed.");
+    }
+    console.log("Circuit compilation succeeded!");
+
+    // Initiate proof generation.
+    console.log("2. Proving circuit...");
+    const proofInput = JSON.stringify({ a: "7", b: "42" });
+    const proveResponse = await axios.post(
+      API_URL + `/circuit/${circuitId}/prove` + apiKeyQueryString,
+      { proof_input: proofInput },
+      { headers: headersUrlEncode, validateStatus: (status) => status === 201 },
+    );
+    const proofId = proveResponse.data.proof_id;
+
+    // Poll the proof detail endpoint until the compilation status is `Ready` or `Failed`.
+    const proofDetailResponse = await pollForStatus(`/proof/${proofId}/detail`);
+
+    // Check for proving issues.
+    const proofDetailStatus = proveResponse.data.status;
+    if (proofDetailStatus === "Failed") {
+      throw new Error("Proving failed");
+    }
+
+    // Retrieve output from the proof.
+    const publicOutput = proofDetailResponse.data.public[0];
+    console.log(`Circuit proof output signal: ${publicOutput}`);
+  } catch (error) {
+    if (error instanceof Error) {
+      console.error(error.message);
+    } else {
+      console.error("An unknown error occurred.");
+    }
+  }
+}
+
+if (require.main === module) {
+  main();
+}

--- a/example-code/quickstart.py
+++ b/example-code/quickstart.py
@@ -6,7 +6,7 @@ import time
 import requests  # pip install requests
 
 # NOTE: Provide your API Key here
-api_key = os.getenv("FORGE_API_KEY", "")
+API_KEY = os.getenv("FORGE_API_KEY", "")
 
 API_VERSION = "v1"
 API_URL = f"https://forge.sindri.app/api/{API_VERSION}/"

--- a/example-code/quickstart.py
+++ b/example-code/quickstart.py
@@ -1,11 +1,12 @@
 import json
+import os
 import sys
 import time
 
 import requests  # pip install requests
 
 # NOTE: Provide your API Key here
-api_key = ""
+api_key = os.getenv("FORGE_API_KEY", "")
 
 API_VERSION = "v1"
 API_URL = f"https://forge.sindri.app/api/{API_VERSION}/"
@@ -29,7 +30,7 @@ assert response.status_code == 201, f"Expected status code 201, received {respon
 circuit_id = response.json().get("circuit_id")  # Obtain circuit_id
 
 # Load the circuit .tar.gz file
-files = {"files": open("../circom/multiplier2.tar.gz", "rb")}
+files = {"files": open(os.path.join("..", "circom", "multiplier2.tar.gz"), "rb")}
 
 # Upload the circuit file
 response = requests.post(

--- a/example-code/quickstart.py
+++ b/example-code/quickstart.py
@@ -11,7 +11,7 @@ API_KEY = os.getenv("FORGE_API_KEY", "")
 API_VERSION = "v1"
 API_URL = f"https://forge.sindri.app/api/{API_VERSION}/"
 
-api_key_querystring = f"?api_key={api_key}"
+api_key_querystring = f"?api_key={API_KEY}"
 headers_json = {"Accept": "application/json"}
 headers_multipart = {"Accept": "multipart/form-data"}
 headers_urlencode = {


### PR DESCRIPTION
This adds adds a new `forge-sample-data/example-code/quickstart.js` script to make it easier for people using JavaScript to get started with Forge. The `example-code` README file has been updated to include instructions for both the JavaScript and Python scripts.

The JavaScript file very closely mirrors the existing `quickstart.py` with some minor structural changes like abstracting out the polling functionality and introducing a `main()` function so that there aren't top-level `await` statements. There are also a couple of small improvements that were also backported to the Python script: cross-platform file path construction and support for setting the API key using a `FORGE_API_KEY` environment variable.

The scripts can now be run like this

```bash
# Provide the API key without modifying the scripts.
export FORGE_API_KEY=<your-api-key>

# JavaScript Quickstart.
node quickstart.js

# Python Quickstart.
python quickstart.py
```

and each script should produce identical output (modulo the stochastic timing information).


Closes #12
